### PR TITLE
Assignment rework

### DIFF
--- a/self_host/lexer.xk
+++ b/self_host/lexer.xk
@@ -26,7 +26,7 @@ impl Lexer {
     }
     
     priv fn readChar(self, offset: i32) {
-      self.pos = self.pos + offset;
+      self.pos += offset;
     }
     
     priv fn peekChar(self, offset: i32) -> char {

--- a/src/main/java/github/io/chaosunity/xikou/ast/expr/AssignmentExpr.java
+++ b/src/main/java/github/io/chaosunity/xikou/ast/expr/AssignmentExpr.java
@@ -5,23 +5,31 @@ import github.io.chaosunity.xikou.resolver.types.AbstractType;
 
 public final class AssignmentExpr implements Expr {
 
-  public final Expr lhs;
+  public final int targetCount;
+  public final Expr[] targets;
   public final Token assignOpToken;
   public final Expr rhs;
 
-  public AssignmentExpr(Expr lhs, Token assignOpToken, Expr rhs) {
-    this.lhs = lhs;
+  public AssignmentExpr(int targetCount, Expr[] targets, Token assignOpToken, Expr rhs) {
+    this.targetCount = targetCount;
+    this.targets = targets;
     this.assignOpToken = assignOpToken;
     this.rhs = rhs;
   }
 
   @Override
   public AbstractType getType() {
-    return lhs.getType();
+    return targets[0].getType();
   }
 
   @Override
   public boolean isAssignable() {
-    return lhs.isAssignable();
+    for (int i = 0; i < targetCount; i++) {
+      if (!targets[i].isAssignable()) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/src/main/java/github/io/chaosunity/xikou/gen/ExprGen.java
+++ b/src/main/java/github/io/chaosunity/xikou/gen/ExprGen.java
@@ -21,6 +21,7 @@ import github.io.chaosunity.xikou.ast.expr.NullLiteral;
 import github.io.chaosunity.xikou.ast.expr.ReturnExpr;
 import github.io.chaosunity.xikou.ast.expr.StringLiteralExpr;
 import github.io.chaosunity.xikou.ast.expr.WhileExpr;
+import github.io.chaosunity.xikou.lexer.Token;
 import github.io.chaosunity.xikou.lexer.TokenType;
 import github.io.chaosunity.xikou.resolver.FieldRef;
 import github.io.chaosunity.xikou.resolver.LocalVarRef;
@@ -192,14 +193,18 @@ public class ExprGen {
   private void genAssignmentExpr(MethodVisitor mw, AssignmentExpr assignmentExpr) {
     int assignmentTargetCount = 0;
     Expr[] assignmentTargets = new Expr[1];
+    Token[] assignOperators = new Token[1];
     Expr lhsHolder = assignmentExpr.lhs, rhs = assignmentExpr.rhs;
 
     // Collect all assignment targets
     while (lhsHolder != null) {
       if (assignmentTargetCount >= assignmentTargets.length) {
-        Expr[] newArr = new Expr[assignmentTargets.length * 2];
-        System.arraycopy(assignmentTargets, 0, newArr, 0, assignmentTargets.length);
-        assignmentTargets = newArr;
+        Expr[] newTargetArr = new Expr[assignmentTargets.length * 2];
+        System.arraycopy(assignmentTargets, 0, newTargetArr, 0, assignmentTargets.length);
+        assignmentTargets = newTargetArr;
+        Token[] newTokenArr = new Token[assignmentTargets.length * 2];
+        System.arraycopy(assignOperators, 0, newTokenArr, 0, assignOperators.length);
+        assignOperators = newTokenArr;
       }
 
       if (!(lhsHolder instanceof AssignmentExpr)) {
@@ -209,7 +214,7 @@ public class ExprGen {
 
       AssignmentExpr lhsAssignment = (AssignmentExpr) lhsHolder;
 
-      assignmentTargets[assignmentTargetCount++] = lhsAssignment.rhs;
+      assignmentTargets[assignmentTargetCount] = lhsAssignment.rhs;
       lhsHolder = lhsAssignment.lhs;
     }
 

--- a/src/main/java/github/io/chaosunity/xikou/lexer/Lexer.java
+++ b/src/main/java/github/io/chaosunity/xikou/lexer/Lexer.java
@@ -156,6 +156,11 @@ public class Lexer {
     }
 
     if (currentChar == '+') {
+      if (peekChar(1) == '=') {
+        readChar(2);
+        return new Token(TokenType.PlusEqual, "+=");
+      }
+      
       readChar(1);
       return new Token(TokenType.Plus, "+");
     }
@@ -164,6 +169,11 @@ public class Lexer {
       if (peekChar(1) == '>') {
         readChar(2);
         return new Token(TokenType.SlimArrow, "->");
+      }
+
+      if (peekChar(1) == '=') {
+        readChar(2);
+        return new Token(TokenType.MinusEqual, "-=");
       }
 
       readChar(1);

--- a/src/main/java/github/io/chaosunity/xikou/lexer/Lexer.java
+++ b/src/main/java/github/io/chaosunity/xikou/lexer/Lexer.java
@@ -160,7 +160,7 @@ public class Lexer {
         readChar(2);
         return new Token(TokenType.PlusEqual, "+=");
       }
-      
+
       readChar(1);
       return new Token(TokenType.Plus, "+");
     }

--- a/src/main/java/github/io/chaosunity/xikou/lexer/TokenType.java
+++ b/src/main/java/github/io/chaosunity/xikou/lexer/TokenType.java
@@ -3,7 +3,7 @@ package github.io.chaosunity.xikou.lexer;
 public enum TokenType {
   CharLiteral, StringLiteral, NumberLiteral, Identifier, OpenParenthesis, CloseParenthesis,
   OpenBrace, CloseBrace, OpenBracket, CloseBracket, Dot, Comma, SemiColon, Colon, DoubleColon,
-  Equal, DoubleEqual, NotEqual, Greater, GreaterEqual, Lesser, LesserEqual, DoubleAmpersand, DoublePipe, Plus, Minus, SlimArrow, Pub, Priv,
+  Equal, PlusEqual, MinusEqual, DoubleEqual, NotEqual, Greater, GreaterEqual, Lesser, LesserEqual, DoubleAmpersand, DoublePipe, Plus, Minus, SlimArrow, Pub, Priv,
   Mut, Pkg, Class, Enum, Fn, Const, Let, Self, Impl, Null, Return, As, If, Else, While, EOF;
 
   public static final TokenType[] KEYWORDS = new TokenType[]{Pub, Priv, Mut, Pkg, Class, Enum, Fn,
@@ -28,6 +28,8 @@ public enum TokenType {
       case DoublePipe:
         return 2;
       case Equal:
+      case PlusEqual:
+      case MinusEqual:
         return 1;
       default:
         return 0;

--- a/src/main/java/github/io/chaosunity/xikou/parser/Parser.java
+++ b/src/main/java/github/io/chaosunity/xikou/parser/Parser.java
@@ -586,9 +586,24 @@ public class Parser {
         case Equal:
         case PlusEqual:
         case MinusEqual: {
-          int targetCount = 0;
-          Expr[] targets = new Expr[1];
-          
+          int targetCount = 2;
+          Expr[] targets = {lhs, rhs};
+
+          while (lexer.acceptToken(operatorToken.type)) {
+            if (targetCount >= targets.length) {
+              Expr[] newArr = new Expr[targetCount * 2];
+              System.arraycopy(targets, 0, newArr, 0, targetCount);
+              targets = newArr;
+            }
+
+            targets[targetCount++] = parseInfixExpr(precedence);
+          }
+
+          rhs = targets[targetCount - 1];
+          targets[--targetCount] = null;
+
+          lhs = new AssignmentExpr(targetCount, targets, operatorToken, rhs);
+          break;
         }
         default:
           throw new IllegalStateException(
@@ -717,11 +732,11 @@ public class Parser {
 
       return new IfExpr(condExpr, trueBranchExpr, falseBranchExpr);
     }
-    
+
     if (lexer.acceptToken(TokenType.While)) {
       Expr condExpr = parseExpr();
       BlockExpr iterExpr = parseBlockExpr();
-      
+
       return new WhileExpr(condExpr, iterExpr);
     }
 

--- a/src/main/java/github/io/chaosunity/xikou/parser/Parser.java
+++ b/src/main/java/github/io/chaosunity/xikou/parser/Parser.java
@@ -534,7 +534,7 @@ public class Parser {
   private Expr parseInfixExpr(int parentPrecedence) {
     Expr lhs = parseSuffixExpr();
 
-    while (true) {
+    while (!lexer.peekToken(TokenType.EOF)) {
       Token operatorToken = lexer.getCurrentToken();
       int precedence = operatorToken.type.getInfixPrecedence();
       if (precedence == 0 || precedence <= parentPrecedence) {
@@ -584,8 +584,12 @@ public class Parser {
           lhs = new CompareExpr(lhs, operatorToken, rhs);
           break;
         case Equal:
-          lhs = new AssignmentExpr(lhs, operatorToken, rhs);
-          break;
+        case PlusEqual:
+        case MinusEqual: {
+          int targetCount = 0;
+          Expr[] targets = new Expr[1];
+          
+        }
         default:
           throw new IllegalStateException(
               String.format("ICE: %s is not a valid infix operator", operatorToken.type));

--- a/src/main/java/github/io/chaosunity/xikou/resolver/Resolver.java
+++ b/src/main/java/github/io/chaosunity/xikou/resolver/Resolver.java
@@ -383,16 +383,30 @@ public final class Resolver {
       throw new IllegalStateException("Illegal assignment");
     }
 
+    AbstractType lhsType = expr.lhs.getType(), rhsType = expr.rhs.getType();
+
     if (expr.rhs.getType() == PrimitiveType.VOID) {
       throw new IllegalStateException("void type cannot be used as value");
     }
 
-    if (!TypeUtils.isInstanceOf(expr.rhs.getType(), expr.lhs.getType())) {
-      throw new IllegalStateException(
-          String.format("Illegal assignment: %s is not compatible with %s",
-              expr.rhs.getType().getInternalName(),
-              expr.lhs.getType().getInternalName()));
+    switch (expr.assignOpToken.type) {
+      case Equal:
+        if (!TypeUtils.isInstanceOf(rhsType, lhsType)) {
+          throw new IllegalStateException(
+              String.format("Illegal assignment: %s is not compatible with %s",
+                  expr.rhs.getType().getInternalName(),
+                  expr.lhs.getType().getInternalName()));
+        }
+        break;
+      case PlusEqual:
+      case MinusEqual:
+        if (!lhsType.equals(rhsType)) {
+          throw new IllegalStateException(
+              "Illegal assignment: cannot perform arithmetic operation on different types");
+        }
+        break;
     }
+
   }
 
   private void resolveCastExpr(CastExpr expr, Scope scope) {
@@ -427,7 +441,7 @@ public final class Resolver {
       throw new IllegalStateException("If-else condition must be bool");
     }
   }
-  
+
   private void resolveWhileExpr(WhileExpr expr, Scope scope) {
     resolveExpr(expr.condExpr, scope);
     resolveExpr(expr.iterExpr, scope.extend());


### PR DESCRIPTION
- Now assignment expressions is grouped and chained by operator types, for example, consider expression `self.pos += offset += flag = 1;`, the equivalent pseudo expression would be:
```rs
AssignmentExpr {
    targets: [
        "self.pos",
        "offset"
    ],
    rhs: AssignmentExpr {
        targets: [
            "flag"
        ],
        rhs: "1",
        operator: "="
    },
    operator: "+="
}
```
This gains code generation  more straightforward way  to generate optimized bytecode (notice that is still not the optimal solution)